### PR TITLE
Add quote_char option

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,21 @@ INVALID_EMAIL,bob
 
 The error returned should be: `{ "E-Mail" => "is invalid" }`
 
+### Complex quoting (Illegal quoting problem)
+
+```ruby
+CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR")
+  # => CSV::MalformedCSVError: Illegal quoting in line 1.
+```
+
+The problem is that the CSV comma-delimited text should entirely surround by `"`
+not in part or do not contain `"` at all. You can pass `quote_char` option.
+
+```ruby
+CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR", quote_char: "\x00")
+  # => [ ["1", "Glk", "Lev \"The Black Spider\" Yashin", "USSR"] ]
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -340,16 +340,21 @@ The error returned should be: `{ "E-Mail" => "is invalid" }`
 ### Complex quoting (Illegal quoting problem)
 
 ```ruby
-CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR")
-  # => CSV::MalformedCSVError: Illegal quoting in line 1.
+import = ImportUserCSV.new(content: "email,name\nbob@example.com, bob \"the dude\"")
+import.run!
+import.report.status
+  # => :invalid_csv_file
+import.report.messages
+  # => CSV::MalformedCSVError: Illegal quoting in line 2.
 ```
 
 The problem is that the CSV comma-delimited text should entirely surround by `"`
 not in part or do not contain `"` at all. You can pass `quote_char` option.
 
 ```ruby
-CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR", quote_char: "\x00")
-  # => [ ["1", "Glk", "Lev \"The Black Spider\" Yashin", "USSR"] ]
+import = ImportUserCSV.new(content: "email,name\nbob@example.com, bob \"the dude\"", quote_char: "'")
+import.run!
+  # => [ ["bob@example.com", "bob \"the dude\""] ]
 ```
 
 ## Development

--- a/lib/csv_importer/csv_reader.rb
+++ b/lib/csv_importer/csv_reader.rb
@@ -7,12 +7,13 @@ module CSVImporter
     attribute :content, String
     attribute :file # IO
     attribute :path, String
+    attribute :quote_char, String, default: '"'
 
     def csv_rows
       @csv_rows ||= begin
         sane_content = sanitize_content(read_content)
         separator = detect_separator(sane_content)
-        cells = CSV.parse(sane_content, col_sep: separator)
+        cells = CSV.parse(sane_content, col_sep: separator, quote_char: quote_char)
         sanitize_cells(cells)
       end
     end

--- a/spec/csv_importer/csv_reader_spec.rb
+++ b/spec/csv_importer/csv_reader_spec.rb
@@ -29,14 +29,9 @@ module CSVImporter
       expect(reader.header).to eq ["email", "first_name", "last_name"]
     end
 
-    it "has quote_char option" do
-      reader = CSVReader.new(content: "", quote_char: "|")
-      expect(reader.quote_char).to eq "|"
-    end
-
-    it "has default quote_char value" do
-      reader = CSVReader.new(content: "")
-      expect(reader.quote_char).to eq "\""
+    it "supports custom quote character" do
+      reader = CSVReader.new(content: "first_name,last_name\n'bob','the builder'", quote_char: "'")
+      expect(reader.rows).to eq [["bob", "the builder"]]
     end
   end
 end

--- a/spec/csv_importer/csv_reader_spec.rb
+++ b/spec/csv_importer/csv_reader_spec.rb
@@ -29,5 +29,14 @@ module CSVImporter
       expect(reader.header).to eq ["email", "first_name", "last_name"]
     end
 
+    it "has quote_char option" do
+      reader = CSVReader.new(content: "", quote_char: "|")
+      expect(reader.quote_char).to eq "|"
+    end
+
+    it "has default quote_char value" do
+      reader = CSVReader.new(content: "")
+      expect(reader.quote_char).to eq "\""
+    end
   end
 end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -372,6 +372,12 @@ bob@example.com   ,  true,   bob   ,,"
     expect { import.run! }.to_not raise_error
   end
 
+  it "can change quote_char value" do
+    import = ImportUserCSV.new(content: "", quote_char: "\x00")
+
+    expect(import.csv.quote_char).to eq "\x00"
+  end
+
   describe "#when_invalid" do
     it "could abort" do
       csv_content = "email,confirmed,first_name,last_name
@@ -443,7 +449,7 @@ bob@example.com,false,bob,,|
 BOB@example.com,true,bob,,"
 
       # This importer downcases emails after build
-      import = ImportUserCSVByFirstName.new(
+      ImportUserCSVByFirstName.new(
         content: csv_content,
       ).run!
 

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -372,10 +372,20 @@ bob@example.com   ,  true,   bob   ,,"
     expect { import.run! }.to_not raise_error
   end
 
-  it "can change quote_char value" do
-    import = ImportUserCSV.new(content: "", quote_char: "\x00")
+  it "supports custom quote_char value" do
+    csv_content = "email,confirmed,first_name,last_name
+bob@example.com   ,  true,   bob   , \"the dude\" jones,"
+    import = ImportUserCSV.new(content: csv_content, quote_char: "\x00")
 
-    expect(import.csv.quote_char).to eq "\x00"
+    import.run!
+
+    model = import.report.created_rows.first.model
+    expect(model).to have_attributes(
+      email: "bob@example.com",
+      confirmed_at: Time.new(2012),
+      f_name: "bob",
+      l_name: "\"the dude\" jones"
+    )
   end
 
   describe "#when_invalid" do


### PR DESCRIPTION
Complex quoting (Illegal quoting problem)

```ruby
CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR")
  # => CSV::MalformedCSVError: Illegal quoting in line 1.
```

The problem is that the CSV comma-delimited text should entirely surround by `"` not in part or do not contain `"` at all.

You can pass quote_char option, to solve the problem:
```ruby
CSV.parse("1,Glk,Lev \"The Black Spider\" Yashin,USSR", quote_char: "\x00")
  # => [ ["1", "Glk", "Lev \"The Black Spider\" Yashin", "USSR"] ]
```