### PR TITLE
Pass CSV row attributes to after_build/after_save blocks

### DIFF
--- a/lib/csv_importer/row.rb
+++ b/lib/csv_importer/row.rb
@@ -42,7 +42,7 @@ module CSVImporter
         set_attribute(model, column_definition, value)
       end
 
-      after_build_blocks.each { |block| block.call(model) }
+      after_build_blocks.each { |block| block.call(model, csv_attributes) }
 
       model
     end

--- a/lib/csv_importer/runner.rb
+++ b/lib/csv_importer/runner.rb
@@ -59,7 +59,7 @@ module CSVImporter
           end
 
           add_to_report(row, tags)
-          after_save_blocks.each { |block| block.call(row.model) }
+          after_save_blocks.each { |block| block.call(row.model, row.csv_attributes) }
         end
       end
     end

--- a/spec/csv_importer_spec.rb
+++ b/spec/csv_importer_spec.rb
@@ -505,6 +505,23 @@ BOB@example.com,true,bob,,"
       model = User.find_by(email: "bob+imported@example.com")
       expect(model.created_by_user_id).to eq(current_user_id)
     end
+
+    it "supports acccessing other row attributes" do
+      csv_content = "email,confirmed,first_name,last_name,admin_id
+  bob@example.com,true,bob,,987"
+
+      import = ImportUserCSV.new(content: csv_content) do
+        after_build do |model, attributes|
+          model.created_by_user_id = attributes["admin_id"]
+        end
+      end
+
+      import.run!
+
+      model = User.find_by(email: "bob@example.com")
+
+      expect(model.created_by_user_id).to eq("987")
+    end
   end # describe ".after_build"
 
   describe ".after_save" do
@@ -531,6 +548,24 @@ BOB@example.com,true,bob,,"
       }.to change { success_array }.from([]).to([true, false])
 
       expect(saves_count).to eq 2
+    end
+
+    it "supports acccessing other row attributes" do
+      csv_content = "email,confirmed,first_name,last_name,admin_id
+  bob@example.com,true,bob,,987"
+
+      import = ImportUserCSV.new(content: csv_content) do
+        after_save do |model, attributes|
+          model.created_by_user_id = attributes["admin_id"]
+          model.save
+        end
+      end
+
+      import.run!
+
+      model = User.find_by(email: "bob@example.com")
+
+      expect(model.created_by_user_id).to eq("987")
     end
   end
 end


### PR DESCRIPTION
Pass all row attributes to after_build/after_save blocks; I need this so I can use extra columns to manipulate associations (e.g. when importing Users, find and assign `user.customer_id` from a `customer_name` column)