### PR TITLE
Ability to remove lines that have been commented out

### DIFF
--- a/lib/csv_importer/csv_reader.rb
+++ b/lib/csv_importer/csv_reader.rb
@@ -12,9 +12,11 @@ module CSVImporter
     def csv_rows
       @csv_rows ||= begin
         sane_content = sanitize_content(read_content)
-        separator = detect_separator(sane_content)
-        cells = CSV.parse(sane_content, col_sep: separator, quote_char: quote_char)
-        sanitize_cells(cells)
+        separator    = detect_separator(sane_content)
+        cells        = CSV.parse(sane_content, col_sep: separator, quote_char: quote_char)
+        sane_cells   = sanitize_cells(cells)
+        
+        remove_comments(sane_cells)
       end
     end
 
@@ -52,6 +54,17 @@ module CSVImporter
 
     def detect_separator(csv_content)
       SEPARATORS.sort_by { |separator| csv_content.count(separator) }.last
+    end
+
+    # Strip commented rows
+    def remove_comments(rows)
+      comment_char = "#"
+
+      rows.select {|row|
+        first_column = row.first
+        # If first character is #, skip the line
+        not first_column.match(/^#{comment_char}/)
+      }
     end
 
     # Strip cells


### PR DESCRIPTION
Some users were adding comments above the header.
This commit will remove any line starting with a '#' before processing header.

I also lined up assignments, but feel free to change.
We use {} brackets in blocks when we care about the return product and not the side-effect, regardless of the number of lines used, so line 63 has { instead of "do". Feel free to change as per your styles. 

I understand if this doesn't get merged, it's a fairly specific solution to our users, I assume. 