### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ end
 import = ImportUserCSV.new(content: "email\nbob@example.com\nINVALID_EMAIL")
 import.valid_header? # => true
 import.run!
-import.success? # => false
+import.report.success? # => false
 import.report.status # => :aborted
 import.report.message # => "Import aborted"
 ```


### PR DESCRIPTION
import.success? currently throws NoMethodError. The documentation uses import.report.success? in other places.